### PR TITLE
[fix #34] pass rubocop the filenames it expects to see

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,4 +52,5 @@ Write tests and guard will run them.  Make changes and reload the window.  Test 
 
 # Contributors
 
+* [Sebastian Delmont](sd@notso.net)
 * *Your name here!*

--- a/lib/ruby_language_server/good_cop.rb
+++ b/lib/ruby_language_server/good_cop.rb
@@ -96,9 +96,15 @@ module RubyLanguageServer
     private
 
     def offenses(text, filename)
-      processed_source = RuboCop::ProcessedSource.new(text, 2.4, filename_relative_to_project(filename))
-      offenses = inspect_file(processed_source)
-      offenses.compact.flatten
+      filename = filename_relative_to_project(filename)
+
+      if excluded_file?(filename)
+        []
+      else
+        processed_source = RuboCop::ProcessedSource.new(text, 2.4, filename)
+        offenses = inspect_file(processed_source)
+        offenses.compact.flatten
+      end
     end
 
     def filename_relative_to_project(filename)
@@ -126,6 +132,11 @@ module RubyLanguageServer
       project_path = RubyLanguageServer::ProjectManager.root_path + '.rubocop.yml'
       possible_config_paths = [project_path, fallback_pathname.to_s]
       possible_config_paths.detect { |path| File.exist?(path) }
+    end
+
+    def excluded_file?(filename)
+      file_config = @config_store.for(filename)
+      file_config.file_to_exclude?(filename)
     end
   end
 end

--- a/lib/ruby_language_server/good_cop.rb
+++ b/lib/ruby_language_server/good_cop.rb
@@ -96,9 +96,13 @@ module RubyLanguageServer
     private
 
     def offenses(text, filename)
-      processed_source = RuboCop::ProcessedSource.new(text, 2.4, filename)
+      processed_source = RuboCop::ProcessedSource.new(text, 2.4, filename_relative_to_project(filename))
       offenses = inspect_file(processed_source)
       offenses.compact.flatten
+    end
+
+    def filename_relative_to_project(filename)
+      filename.gsub(RubyLanguageServer::ProjectManager.root_uri, ENV['RUBY_LANGUAGE_SERVER_PROJECT_ROOT'] || '/project/')
     end
 
     def initialization_offenses

--- a/lib/ruby_language_server/project_manager.rb
+++ b/lib/ruby_language_server/project_manager.rb
@@ -27,11 +27,26 @@ module RubyLanguageServer
 
         path.end_with?(File::SEPARATOR) ? path : "#{path}#{File::SEPARATOR}"
       end
+
+      def root_uri=(uri)
+        ROOT_PATH_MUTEX.synchronize do
+          if uri
+            uri = "#{uri}/" unless uri.end_with?('/')
+            @_root_uri = uri
+          end
+        end
+      end
+
+      def root_uri
+        @_root_uri || "file://#{root_path}"
+      end
     end
 
-    def initialize(path)
+    def initialize(path, uri = nil)
       # Should probably lock for read, but I'm feeling crazy!
       self.class.root_path = path if self.class.root_path.nil?
+      self.class.root_uri = uri if uri
+
       @root_uri = "file://#{path}"
       # This is {uri: code_file} where content stuff is like
       @uri_code_file_hash = {}

--- a/lib/ruby_language_server/server.rb
+++ b/lib/ruby_language_server/server.rb
@@ -10,7 +10,8 @@ module RubyLanguageServer
     def on_initialize(params)
       RubyLanguageServer.logger.info("on_initialize: #{params}")
       root_path = params['rootPath']
-      @project_manager = ProjectManager.new(root_path)
+      root_uri = params['rootUri']
+      @project_manager = ProjectManager.new(root_path, root_uri)
       gem_string = ENV.fetch('ADDITIONAL_GEMS') {}
       gem_array = (gem_string.split(',').compact.map(&:strip).reject { |string| string == '' } if gem_string && !gem_string.empty?)
       @project_manager.install_additional_gems(gem_array)

--- a/spec/lib/ruby_language_server/good_cop_spec.rb
+++ b/spec/lib/ruby_language_server/good_cop_spec.rb
@@ -5,7 +5,7 @@ require 'minitest/autorun'
 
 describe RubyLanguageServer::GoodCop do
   before :each do
-    RubyLanguageServer::ProjectManager.new('/foo') # GoodCop looks to the ProjectManager to get the project root path
+    RubyLanguageServer::ProjectManager.new('/foo', 'file:///remote') # GoodCop looks to the ProjectManager to get the project root path
   end
 
   let(:good_cop) { RubyLanguageServer::GoodCop.new }
@@ -13,6 +13,13 @@ describe RubyLanguageServer::GoodCop do
   describe 'basics' do
     it 'should init without config' do
       refute_nil(good_cop)
+    end
+
+    it 'should know how to convert filenames to project-relative paths' do
+      assert_equal(good_cop.send(:filename_relative_to_project, 'test.rb'), 'test.rb')
+      assert_equal(good_cop.send(:filename_relative_to_project, 'file:///remote/test.rb'), '/project/test.rb')
+      assert_equal(good_cop.send(:filename_relative_to_project, 'file:///remote/path/test.rb'), '/project/path/test.rb')
+      assert_equal(good_cop.send(:filename_relative_to_project, '/local/path/test.rb'), '/local/path/test.rb')
     end
   end
 

--- a/spec/lib/ruby_language_server/project_manager_spec.rb
+++ b/spec/lib/ruby_language_server/project_manager_spec.rb
@@ -7,7 +7,7 @@ describe RubyLanguageServer::ProjectManager do
   before do
   end
 
-  let(:pm) { RubyLanguageServer::ProjectManager.new('/foo') }
+  let(:pm) { RubyLanguageServer::ProjectManager.new('/foo', 'file:///foo/') }
 
   describe 'ProjectManager' do
     it 'must init' do
@@ -27,6 +27,13 @@ describe RubyLanguageServer::ProjectManager do
       ENV['RUBY_LANGUAGE_SERVER_PROJECT_ROOT'] = '/proj/'
       assert_equal('/proj/', RubyLanguageServer::ProjectManager.root_path)
       ENV['RUBY_LANGUAGE_SERVER_PROJECT_ROOT'] = nil
+    end
+  end
+
+  describe '#root_uri' do
+    it 'should store a root uri' do
+      refute_nil(pm)
+      assert_equal('file:///foo/', RubyLanguageServer::ProjectManager.root_uri)
     end
   end
 


### PR DESCRIPTION
rubocop expects to see absolute filenames, but on the working directory inside of docker, not the uri passed by the editor.

So we store the project's base uri in `project_manager` and then use it to "fix" filenames before passing them to rubocop.