### PR TITLE
Fixes for Windows

### DIFF
--- a/exe/ruby_language_server
+++ b/exe/ruby_language_server
@@ -3,6 +3,11 @@
 
 $LOAD_PATH << File.join(__dir__, '..', 'lib')
 
+if Gem.win_platform?
+  $stdin.binmode
+  $stdout.binmode
+end
+
 require 'ruby_language_server'
 
 application = RubyLanguageServer::Application.new

--- a/lib/config/initializers/active_record.rb
+++ b/lib/config/initializers/active_record.rb
@@ -10,7 +10,12 @@ ActiveRecord::Base.establish_connection(
 
 database = ActiveRecord::Base.connection.instance_variable_get :@connection
 database.enable_load_extension(1)
-database.load_extension('/usr/local/lib/liblevenshtein.so.0.0.0')
+if Gem.win_platform?
+  # load DLL from PATH
+  database.load_extension('liblevenshtein.dll')
+else
+  database.load_extension('/usr/local/lib/liblevenshtein.so.0.0.0')
+end
 database.enable_load_extension(0)
 
 if ENV['LOG_LEVEL'] == 'DEBUG'

--- a/lib/config/initializers/active_record.rb
+++ b/lib/config/initializers/active_record.rb
@@ -2,7 +2,7 @@
 
 ActiveRecord::Base.establish_connection(
   adapter: 'sqlite3',
-  database: 'file::memory:?cache=shared',
+  database: 'file:memory?mode=memory&cache=shared',
   # database: '/database',
   pool: 5, # does not seem to help
   checkout_timeout: 30.seconds # does not seem to help


### PR DESCRIPTION
I added some fixes for Windows.

* file::memory: can not be used on Windows (This is not a bug of ruby_language_server)
* load DLL on Windows
* set binmode on Windows
