### PR TITLE
Issue installing rubocop gems: no implicit conversion of nil into String #66

### DIFF
--- a/lib/ruby_language_server/gem_installer.rb
+++ b/lib/ruby_language_server/gem_installer.rb
@@ -19,11 +19,17 @@ module RubyLanguageServer
           # For some reason, installing bundler makes it unhappy.  Whatever.
           Gem::Specification.reject { |s| s.name == 'bundler' }.each do |specification|
             gem_name = specification.name
-            gem(gem_name, specification.version.to_s)
-            gems_already_installed << gem_name
+            begin
+              gem(gem_name, specification&.version&.to_s)
+              gems_already_installed << gem_name
+            rescue Error => e
+              RubyLanguageServer.logger.error("Error loading rubocop gem #{gem_name} #{e}")
+            end
           end
           additional_gem_names.each do |gem_name|
             gem gem_name unless gems_already_installed.include?(gem_name)
+          rescue Error => e
+            RubyLanguageServer.logger.error("Error loading rubocop gem! #{gem_name} #{e}")
           end
         end
       end


### PR DESCRIPTION
https://github.com/kwerle/ruby_language_server/issues/66

Make rubocop gem loading a lot more robust/forgiving