### PR TITLE
Features/47 shallow parsing

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -16,6 +16,8 @@ require:
 AllCops:
   TargetRubyVersion: 3.1
   NewCops: enable
+  Exclude:
+    - 'spec/fixture_files/**/*'
 
 Layout/SpaceInsideHashLiteralBraces:
   Enabled: false

--- a/lib/ruby_language_server/code_file.rb
+++ b/lib/ruby_language_server/code_file.rb
@@ -108,7 +108,7 @@ module RubyLanguageServer
       update(text: new_text, refresh_root_scope: true)
     end
 
-    def refresh_scopes_if_needed
+    def refresh_scopes_if_needed(shallow: false)
       return unless refresh_root_scope
 
       RubyLanguageServer.logger.debug("Asking about root_scope for #{uri}")
@@ -117,7 +117,7 @@ module RubyLanguageServer
           self.class.transaction do
             scopes.clear
             variables.clear
-            new_root = ScopeParser.new(text).root_scope
+            new_root = ScopeParser.new(text, shallow).root_scope
             RubyLanguageServer.logger.debug("new_root.children #{new_root.children.as_json}") if new_root&.children
             raise ActiveRecord::Rollback if new_root.nil? || new_root.children.blank?
 

--- a/lib/ruby_language_server/project_manager.rb
+++ b/lib/ruby_language_server/project_manager.rb
@@ -198,7 +198,7 @@ module RubyLanguageServer
           begin
             ActiveRecord::Base.connection_pool.with_connection do |_connection|
               update_document_content(host_uri, text)
-              code_file_for_uri(host_uri).refresh_scopes_if_needed
+              code_file_for_uri(host_uri).refresh_scopes_if_needed(shallow: true)
             end
           rescue StandardError => e
             RubyLanguageServer.logger.warn("Error updating: #{e}\n#{e.backtrace * "\n"}")

--- a/lib/ruby_language_server/scope_parser.rb
+++ b/lib/ruby_language_server/scope_parser.rb
@@ -17,9 +17,10 @@ module RubyLanguageServer
     include ScopeParserCommands::RubyCommands
     attr_reader :sexp, :lines, :current_scope
 
-    def initialize(sexp, lines = 1)
+    def initialize(sexp, lines = 1, shallow = false)
       @sexp = sexp
       @lines = lines
+      @shallow = shallow
       @root_scope = nil
     end
 
@@ -183,9 +184,13 @@ module RubyLanguageServer
       end
 
       case name
-      when 'public', 'private', 'protected'
-        # FIXME: access control...
+      when 'public', 'protected' # I don't think these get called ever
         process(rest)
+      when 'private' # I don't think these get called ever
+        # FIXME: access control...
+        return process(rest) unless @shallow
+
+        process([])
       when 'delegate'
         # on_delegate(*args[0][1..-1])
       when 'def_delegator', 'def_instance_delegator'
@@ -233,6 +238,8 @@ module RubyLanguageServer
     private
 
     def add_variable(name, line, column, scope = @current_scope)
+      return if @shallow
+
       newvar = scope.variables.where(name:).first_or_create!(
         line:,
         column:,
@@ -259,7 +266,11 @@ module RubyLanguageServer
     def add_scope(args, rest, type)
       (_, name, (line, column)) = args
       scope = push_scope(type, name, line, column)
-      process(rest)
+      if type == ScopeData::Scope::TYPE_METHOD && @shallow
+        process([])
+      else
+        process(rest)
+      end
       pop_scope
       scope
     end
@@ -294,14 +305,14 @@ module RubyLanguageServer
   class ScopeParser < Ripper
     attr_reader :root_scope
 
-    def initialize(text)
+    def initialize(text, shallow = false)
       text ||= '' # empty is the same as nil - but it doesn't crash
       begin
         sexp = self.class.sexp(text)
       rescue TypeError => e
         RubyLanguageServer.logger.error("Exception in sexp: #{e} for text: #{text}")
       end
-      processor = SEXPProcessor.new(sexp, text.split("\n").length)
+      processor = SEXPProcessor.new(sexp, text.split("\n").length, shallow)
       @root_scope = processor.root_scope
     end
   end

--- a/lib/ruby_language_server/scope_parser.rb
+++ b/lib/ruby_language_server/scope_parser.rb
@@ -184,13 +184,9 @@ module RubyLanguageServer
       end
 
       case name
-      when 'public', 'protected' # I don't think these get called ever
-        process(rest)
-      when 'private' # I don't think these get called ever
+      when 'public', 'private', 'protected'
         # FIXME: access control...
-        return process(rest) unless @shallow
-
-        process([])
+        process(rest)
       when 'delegate'
         # on_delegate(*args[0][1..-1])
       when 'def_delegator', 'def_instance_delegator'

--- a/spec/fixture_files/scope_parser.sample.rb
+++ b/spec/fixture_files/scope_parser.sample.rb
@@ -1,0 +1,40 @@
+bogus = Some::Bogus
+module Foo
+  class Bar
+    @bottom = 1
+
+    public def baz(bing, zing)
+      zang = 1
+      @biz = bing
+      @biz = bang
+    end
+
+    private
+
+    def ding
+    end
+  end
+
+  class Nar < Bar
+    attr :top
+
+    private
+
+    def naz(ning)
+      @niz = ning
+    end
+  end
+
+  module Zar
+    class << self
+      def zoo(par)
+        paf = par
+      end
+    end
+
+    def self.zor(par)
+      pax = par
+    end
+  end
+
+end

--- a/spec/lib/ruby_language_server/scope_parser_spec.rb
+++ b/spec/lib/ruby_language_server/scope_parser_spec.rb
@@ -4,172 +4,168 @@ require_relative '../../test_helper'
 require 'minitest/autorun'
 
 describe RubyLanguageServer::ScopeParser do
+  before do
+    @code_file_lines = File.new('spec/fixture_files/scope_parser.sample.rb', 'r').read
+  end
+
   describe 'Small file' do
-    before do
-      @code_file_lines = <<-SOURCE
-      bogus = Some::Bogus
-      module Foo
-        class Bar
-          @bottom = 1
+    describe 'shallow parsing' do
+      before do
+        @parser = RubyLanguageServer::ScopeParser.new(@code_file_lines, true)
+      end
 
-          public def baz(bing, zing)
-            zang = 1
-            @biz = bing
-            @biz = bang
-          end
+      # Life is unfair.  `private` does not start a block - it just sets a flag.  So I may circle back to this.
+      # it 'does not find private methods' do
+      #   bar = @parser.root_scope.children.first.children.detect { |child| child.full_name == 'Foo::Bar' }
+      #   assert_equal(%w[baz], bar.children.map(&:name).sort)
+      # end
+      it 'does not add any variables at any scope' do
+        assert_equal(RubyLanguageServer::ScopeData::Variable.all.count, 0)
+      end
+    end
 
+    describe 'normal parsing' do
+      before do
+        @parser = RubyLanguageServer::ScopeParser.new(@code_file_lines)
+      end
+
+      it 'records all the variables (as opposed to shallow)' do
+        assert_equal(RubyLanguageServer::ScopeData::Variable.order(:name).pluck(:name), [
+                       "@biz", "@bottom", "@niz", "bing", "bogus", "ning", "paf", "par", "par", "pax", "zang", "zing"
+                     ])
+      end
+
+      describe 'class << self' do
+        let(:zar) { @parser.root_scope.self_and_descendants.detect { |child| child.full_name == 'Foo::Zar' } }
+
+        it 'should add methods' do
+          assert_equal(%w[zoo zor], zar.children.map(&:name).sort)
         end
+      end
 
-        class Nar < Bar
-          attr :top
-
-          private
-
-          def naz(ning)
-            @niz = ning
-          end
+      describe 'full parsing' do
+        it 'finds public and private methods' do
+          bar = @parser.root_scope.children.first.children.detect { |child| child.full_name == 'Foo::Bar' }
+          assert_equal(%w[baz ding], bar.children.map(&:name).sort)
         end
+      end
 
-        module Zar
-          class << self
-            def zoo(par)
-              paf = par
+      it 'has a root scope' do
+        refute_nil(@parser.root_scope)
+      end
+
+      it 'has one module: Foo' do
+        children = @parser.root_scope.children
+        assert_equal(1, children.size)
+        m = children.first
+        assert_equal('Foo', m.name)
+        assert_equal('Foo', m.full_name)
+      end
+
+      it 'module should span the whole file' do
+        m = @parser.root_scope.children.first
+        assert_equal(2, m.top_line)
+        assert_equal(40, m.bottom_line)
+      end
+
+      it 'has two classes' do
+        m = @parser.root_scope.children.first
+        children = m.children
+        assert_equal(3, children.size)
+        bar = m.children.detect { |child| child.full_name == 'Foo::Bar' }
+        assert_equal('Bar', bar.name)
+        assert_equal('Foo::Bar', bar.full_name)
+        nar = m.children.detect { |child| child.full_name == 'Foo::Nar' }
+        assert_equal('Nar', nar.name)
+        assert_equal('Foo::Nar', nar.full_name)
+      end
+
+      it 'should see Nar subclasses Bar' do
+        m = @parser.root_scope.children.first
+        nar = m.children.detect { |child| child.full_name == 'Foo::Nar' }
+        assert_equal('Nar', nar.name)
+        assert_equal('Foo::Bar', nar.superclass_name)
+      end
+
+      it 'has a function Foo::Bar#baz' do
+        m = @parser.root_scope.children.first
+        bar = m.children.first
+        baz_function = bar.children.first
+        assert_equal('baz', baz_function.name)
+        assert_equal(%w[bing zang zing], baz_function.variables.map(&:name).sort)
+      end
+
+      it 'has a couple of ivars for Bar' do
+        m = @parser.root_scope.children.first
+        bar = m.children.detect { |child| child.full_name == 'Foo::Bar' }
+        assert_equal(2, bar.variables.size)
+      end
+
+      it 'has a 3 methods for Nar' do
+        m = @parser.root_scope.children.first
+        nar = m.children.detect { |child| child.full_name == 'Foo::Nar' }
+        assert_equal(3, nar.children.size)
+        assert_equal(['top', 'top=', 'naz'], nar.children.map(&:name))
+      end
+
+      it 'has a couple of ivars for Nar' do
+        m = @parser.root_scope.children.first
+        bar = m.children.detect { |child| child.full_name == 'Foo::Bar' }
+        assert_equal(2, bar.variables.size)
+      end
+    end
+
+    describe 'on_assign' do
+      it 'should handle complex lvars' do
+        RubyLanguageServer::ScopeParser.new('some.tricky.thing = bob')
+      end
+    end
+
+    describe 'initialize' do
+      it 'should deal with nil' do
+        RubyLanguageServer::ScopeParser.new(nil)
+      end
+
+      it 'should deal with empty' do
+        RubyLanguageServer::ScopeParser.new('')
+      end
+    end
+
+    describe 'block with compound variable' do
+      let(:block_source) do
+        <<-BLOCK
+        sum_or_average.each do |(date, c), value|
+        end
+        BLOCK
+      end
+      let(:scope_parser) { RubyLanguageServer::ScopeParser.new(block_source) }
+
+      it "should parse the names" do
+        block_scope = scope_parser.root_scope.children.first
+        assert_equal(1, block_scope.top_line)
+        assert_equal(2, block_scope.bottom_line)
+        assert_equal(%w[date c value], block_scope.variables.map(&:name))
+      end
+    end
+
+    describe 'block' do
+      let(:block_source) do
+        <<-RAKE
+        class SomeClass
+          def some_method
+            # Array of [[object, [key, value]], [object2, [key2, value2]]]
+            items.each do |item, (key, value)|
+              # should see item as a variable
             end
           end
-
-          def self.zor(par)
-            pax = par
-          end
         end
-
+        RAKE
       end
-      SOURCE
-      @parser = RubyLanguageServer::ScopeParser.new(@code_file_lines)
-    end
+      let(:scope_parser) { RubyLanguageServer::ScopeParser.new(block_source) }
 
-    describe 'class << self' do
-      let(:zar) { @parser.root_scope.self_and_descendants.detect { |child| child.full_name == 'Foo::Zar' } }
-
-      it 'should add methods' do
-        assert_equal(%w[zoo zor], zar.children.map(&:name).sort)
+      it 'should find a block with a variable' do
+        assert_equal('item', scope_parser.root_scope.self_and_descendants.last.variables.first.name)
       end
-    end
-
-    it 'should have a root scope' do
-      refute_nil(@parser.root_scope)
-    end
-
-    it 'should have one module' do
-      children = @parser.root_scope.children
-      assert_equal(1, children.size)
-      m = children.first
-      assert_equal('Foo', m.name)
-      assert_equal('Foo', m.full_name)
-    end
-
-    it 'module should span the whole file' do
-      m = @parser.root_scope.children.first
-      assert_equal(2, m.top_line)
-      # assert_equal(20, m.bottom_line) # Uhhh.  Whatever.
-    end
-
-    it 'should have two classes' do
-      m = @parser.root_scope.children.first
-      children = m.children
-      assert_equal(3, children.size)
-      bar = m.children.detect { |child| child.full_name == 'Foo::Bar' }
-      assert_equal('Bar', bar.name)
-      assert_equal('Foo::Bar', bar.full_name)
-      nar = m.children.detect { |child| child.full_name == 'Foo::Nar' }
-      assert_equal('Nar', nar.name)
-      assert_equal('Foo::Nar', nar.full_name)
-    end
-
-    it 'should see Nar subclasses Bar' do
-      m = @parser.root_scope.children.first
-      nar = m.children.detect { |child| child.full_name == 'Foo::Nar' }
-      assert_equal('Nar', nar.name)
-      assert_equal('Foo::Bar', nar.superclass_name)
-    end
-
-    it 'should have a function Foo::Bar#baz' do
-      m = @parser.root_scope.children.first
-      bar = m.children.first
-      baz_function = bar.children.first
-      assert_equal('baz', baz_function.name)
-      assert_equal(%w[bing zang zing], baz_function.variables.map(&:name).sort)
-    end
-
-    it 'should have a couple of ivars for Bar' do
-      m = @parser.root_scope.children.first
-      bar = m.children.detect { |child| child.full_name == 'Foo::Bar' }
-      assert_equal(2, bar.variables.size)
-    end
-
-    it 'should have a 3 methods for Nar' do
-      m = @parser.root_scope.children.first
-      nar = m.children.detect { |child| child.full_name == 'Foo::Nar' }
-      assert_equal(3, nar.children.size)
-      assert_equal(['top', 'top=', 'naz'], nar.children.map(&:name))
-    end
-
-    it 'should have a couple of ivars for Nar' do
-      m = @parser.root_scope.children.first
-      bar = m.children.detect { |child| child.full_name == 'Foo::Bar' }
-      assert_equal(2, bar.variables.size)
-    end
-  end
-
-  describe 'on_assign' do
-    it 'should handle complex lvars' do
-      RubyLanguageServer::ScopeParser.new('some.tricky.thing = bob')
-    end
-  end
-
-  describe 'initialize' do
-    it 'should deal with nil' do
-      RubyLanguageServer::ScopeParser.new(nil)
-    end
-
-    it 'should deal with empty' do
-      RubyLanguageServer::ScopeParser.new('')
-    end
-  end
-
-  describe 'block with compound variable' do
-    let(:block_source) do
-      <<-BLOCK
-      sum_or_average.each do |(date, c), value|
-      end
-      BLOCK
-    end
-    let(:scope_parser) { RubyLanguageServer::ScopeParser.new(block_source) }
-
-    it "should parse the names" do
-      block_scope = scope_parser.root_scope.children.first
-      assert_equal(1, block_scope.top_line)
-      assert_equal(2, block_scope.bottom_line)
-      assert_equal(%w[date c value], block_scope.variables.map(&:name))
-    end
-  end
-
-  describe 'block' do
-    let(:block_source) do
-      <<-RAKE
-      class SomeClass
-        def some_method
-          # Array of [[object, [key, value]], [object2, [key2, value2]]]
-          items.each do |item, (key, value)|
-            # should see item as a variable
-          end
-        end
-      end
-      RAKE
-    end
-    let(:scope_parser) { RubyLanguageServer::ScopeParser.new(block_source) }
-
-    it 'should find a block with a variable' do
-      assert_equal('item', scope_parser.root_scope.self_and_descendants.last.variables.first.name)
     end
   end
 end


### PR DESCRIPTION
When initially scanning a project it is useless to scan the contents of methods - as the variables in those methods don't matter externally.  When a user starts editing a file and actually types anything, the file they are editing will get refreshed and populate the variables for that file - which is all they really need.

Oh.  Except for superclasses, etc.  That's kind of a bummer, but I'm not sure how well that worked before.  Certainly no tests fail...