### PR TITLE
Bump version to 0.9.6 and update changelog with new lookup feature

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,5 +1,9 @@
 # Changelog
 
+#### 0.9.6 Sat Apr 11 12:40:46 PDT 2026
+
+* Better lookup - including climbing the current scopes and fallback to global search
+
 #### 0.9.5 Tue Feb 10 22:04:44 PST 2026
 
 * Fix some scope lookups

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ruby_language_server (0.9.5)
+    ruby_language_server (0.9.6)
       activerecord (~> 8.1)
       amatch
       bundler

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ For gem release
 * bump version in [version.rb](lib/ruby_language_server/version.rb) file and [Gemfile.lock](Gemfile.lock)
 * [CHANGELOG.txt](CHANGELOG.txt)
 * merge to master, etc
-* `make gem_release`
+* `make gem_release` # now done automagically by github action
 
 For docker release
 * `make publish_cross_platform_image`

--- a/lib/ruby_language_server/version.rb
+++ b/lib/ruby_language_server/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module RubyLanguageServer
-  VERSION = '0.9.5'
+  VERSION = '0.9.6'
 end


### PR DESCRIPTION
#### 0.9.6 Sat Apr 11 12:40:46 PDT 2026

* Better lookup - including climbing the current scopes and fallback to global search
